### PR TITLE
V1.8.2 omnibus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Types of changes:
 
 - Added a custom sorting function for the transient table "discovery date" column that 
   always sorts transients lacking discovery dates last whether ascending or descending.
+- Revised the data initialization routine to compare test transient dataset files (e.g. 2010H)
+  without downloading them by S3 etag checksum, and, if a file needs to be installed, only
+  download to local scratch space temporarily in order to upload to the Blast dataset S3 bucket.
+
+### Removed
+
+- The local `/data/cutout_cdn` and `/data/sed_output` directories are no longer provisioned.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Types of changes:
 - Removed the unnecessary "Transient information" workflow task.
 - Hid the workflow diagram from the result pages until a more automated method is devised 
   to generate it when the workflow structure changes.
+- Removed "Transient information" task from `app/host/fixtures/test/test_2010H_onefilter.yaml` so unit tests pass.
 
 ## [1.7.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ Types of changes:
 - Added a custom sorting function for the transient table "discovery date" column that 
   always sorts transients lacking discovery dates last whether ascending or descending.
 
+### Fixed
+
+- Fixed bug in the image cropping task introduced by the transition to using local scratch space
+  instead of a shared persistent volume for generated transient data files.
+- Since the switch to PostgreSQL, there have been failures when rerunning aperture tasks due to
+  foreign key constraint violations. The `_overwrite_or_create_object(Aperture, query, data)`
+  calls have been replaced by a more deliberate algorithm for updating associated objects if they
+  exist.
+
 ## [1.8.1]
 
 ### Fixed

--- a/app/entrypoints/docker-entrypoint.app.sh
+++ b/app/entrypoints/docker-entrypoint.app.sh
@@ -34,7 +34,7 @@ then
   sleep 10
   exit 1
 else
-  echo "\"${INIT_STARTED_DATA}\" not found. Running initialization script..."
+  echo "\"${INIT_STARTED_DATA}\" not found. Running astro data initialization script..."
   touch "${INIT_STARTED_DATA}"
 
   # Create data folders on persistent volume and symlink to expected paths
@@ -61,7 +61,7 @@ then
   sleep 10
   exit 1
 else
-  echo "\"${INIT_STARTED_DB}\" not found. Running initialization script..."
+  echo "\"${INIT_STARTED_DB}\" not found. Running database initialization script..."
   touch "${INIT_STARTED_DB}"
 
   python init_app.py

--- a/app/entrypoints/initialize_data_dirs.sh
+++ b/app/entrypoints/initialize_data_dirs.sh
@@ -11,21 +11,6 @@ cd "${DATA_ROOT_DIR}"
 
 # The creation of symlinks should error if there is a non-symlink
 # file or folder where the symlink should be.
-# if [[ ! -L "${CUTOUT_ROOT}" ]]; then
-#   mkdir -p "${DATA_ROOT_DIR}"/cutout_cdn
-#   mkdir -p "$(dirname "${CUTOUT_ROOT}")"
-#   ln -s "${DATA_ROOT_DIR}/cutout_cdn" "${CUTOUT_ROOT}"
-# fi
-# if [[ ! -L "${CUTOUT_SCRATCH_ROOT}" ]]; then
-#   mkdir -p "${DATA_ROOT_DIR}"/cutout_scratch
-#   mkdir -p "$(dirname "${CUTOUT_SCRATCH_ROOT}")"
-#   ln -s "${DATA_ROOT_DIR}/cutout_scratch" "${CUTOUT_SCRATCH_ROOT}"
-# fi
-# if [[ ! -L "${SED_OUTPUT_ROOT}" ]]; then
-#   mkdir -p "${DATA_ROOT_DIR}"/sed_output
-#   mkdir -p "$(dirname "${SED_OUTPUT_ROOT}")"
-#   ln -s "${DATA_ROOT_DIR}/sed_output" "${SED_OUTPUT_ROOT}"
-# fi
 if [[ ! -L "${TNS_STAGING_ROOT}" ]]; then
   mkdir -p "${DATA_ROOT_DIR}"/tns_staging
   mkdir -p "$(dirname "${TNS_STAGING_ROOT}")"

--- a/app/entrypoints/initialize_data_dirs.sh
+++ b/app/entrypoints/initialize_data_dirs.sh
@@ -11,21 +11,21 @@ cd "${DATA_ROOT_DIR}"
 
 # The creation of symlinks should error if there is a non-symlink
 # file or folder where the symlink should be.
-if [[ ! -L "${CUTOUT_ROOT}" ]]; then
-  mkdir -p "${DATA_ROOT_DIR}"/cutout_cdn
-  mkdir -p "$(dirname "${CUTOUT_ROOT}")"
-  ln -s "${DATA_ROOT_DIR}/cutout_cdn" "${CUTOUT_ROOT}"
-fi
+# if [[ ! -L "${CUTOUT_ROOT}" ]]; then
+#   mkdir -p "${DATA_ROOT_DIR}"/cutout_cdn
+#   mkdir -p "$(dirname "${CUTOUT_ROOT}")"
+#   ln -s "${DATA_ROOT_DIR}/cutout_cdn" "${CUTOUT_ROOT}"
+# fi
 # if [[ ! -L "${CUTOUT_SCRATCH_ROOT}" ]]; then
 #   mkdir -p "${DATA_ROOT_DIR}"/cutout_scratch
 #   mkdir -p "$(dirname "${CUTOUT_SCRATCH_ROOT}")"
 #   ln -s "${DATA_ROOT_DIR}/cutout_scratch" "${CUTOUT_SCRATCH_ROOT}"
 # fi
-if [[ ! -L "${SED_OUTPUT_ROOT}" ]]; then
-  mkdir -p "${DATA_ROOT_DIR}"/sed_output
-  mkdir -p "$(dirname "${SED_OUTPUT_ROOT}")"
-  ln -s "${DATA_ROOT_DIR}/sed_output" "${SED_OUTPUT_ROOT}"
-fi
+# if [[ ! -L "${SED_OUTPUT_ROOT}" ]]; then
+#   mkdir -p "${DATA_ROOT_DIR}"/sed_output
+#   mkdir -p "$(dirname "${SED_OUTPUT_ROOT}")"
+#   ln -s "${DATA_ROOT_DIR}/sed_output" "${SED_OUTPUT_ROOT}"
+# fi
 if [[ ! -L "${TNS_STAGING_ROOT}" ]]; then
   mkdir -p "${DATA_ROOT_DIR}"/tns_staging
   mkdir -p "$(dirname "${TNS_STAGING_ROOT}")"

--- a/app/host/cutouts.py
+++ b/app/host/cutouts.py
@@ -339,8 +339,6 @@ def galex_cutout(position, image_size=None, filter=None):
         obs = obs[obs["t_exptime"] == max(obs["t_exptime"])]
 
     if len(obs):
-        ### stupid MAST thinks we want the exposure time map
-
         fits_image = fits.open(
             obs["dataURL"][0]
             .replace("-exp.fits.gz", "-int.fits.gz")

--- a/app/host/fixtures/test/test_2010H_onefilter.yaml
+++ b/app/host/fixtures/test/test_2010H_onefilter.yaml
@@ -130,17 +130,6 @@
     - processed
     last_modified: 2000-01-23 01:23:45.678000+00:00
     last_processing_time_seconds: 100.0
-- model: host.TaskRegister
-  pk: 33
-  fields:
-    transient:
-    - 2010H
-    task:
-    - Transient information
-    status:
-    - processed
-    last_modified: 2000-01-23 01:23:45.678000+00:00
-    last_processing_time_seconds: 50.0
 - model: host.Aperture
   pk: 1
   fields:

--- a/app/host/object_store.py
+++ b/app/host/object_store.py
@@ -53,7 +53,7 @@ class ObjectStore:
             secure=secure,
         )
         self.initialize_bucket()
-        self.part_size = 10 * 1024 * 1024
+        self.part_size = 16 * 1024 * 1024
 
     def initialize_bucket(self):
         bucket_name = self.bucket
@@ -85,7 +85,11 @@ class ObjectStore:
                 part_size=self.part_size)
         elif file_path:
             logger.debug(f'''Uploading file to object store: "{path}"''')
-            self.client.fput_object(bucket_name=self.bucket, object_name=path, file_path=file_path)
+            self.client.fput_object(
+                bucket_name=self.bucket,
+                object_name=path,
+                file_path=file_path,
+                part_size=self.part_size)
 
     def get_object(self, path=""):
         response = None


### PR DESCRIPTION
Fixes #372 
Fixes #373
Resolves #374

## Description of the Change

### Changed

- Added a custom sorting function for the transient table "discovery date" column that 
  always sorts transients lacking discovery dates last whether ascending or descending.
- Revised the data initialization routine to compare test transient dataset files (e.g. 2010H)
  without downloading them by S3 etag checksum, and, if a file needs to be installed, only
  download to local scratch space temporarily in order to upload to the Blast dataset S3 bucket.

### Removed

- The local `/data/cutout_cdn` and `/data/sed_output` directories are no longer provisioned.
- Removed "Transient information" task from `app/host/fixtures/test/test_2010H_onefilter.yaml` so unit tests pass.

### Fixed

- Fixed bug in the image cropping task introduced by the transition to using local scratch space
  instead of a shared persistent volume for generated transient data files.
- Since the switch to PostgreSQL, there have been failures when rerunning aperture tasks due to
  foreign key constraint violations. The `_overwrite_or_create_object(Aperture, query, data)`
  calls have been replaced by a more deliberate algorithm for updating associated objects if they
  exist.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner
