### PR TITLE
WIP: Manual aperture dragging implementation

### DIFF
--- a/app/host/plotting_utils.py
+++ b/app/host/plotting_utils.py
@@ -13,12 +13,13 @@ from astropy.visualization import PercentileInterval
 from astropy.wcs import WCS
 from bokeh.embed import components
 from bokeh.layouts import gridplot
-# from bokeh.models import ColumnDataSource
+from bokeh.models import ColumnDataSource
 from bokeh.models import HoverTool
 from bokeh.models import LabelSet
+from bokeh.models import PointDrawTool
 from bokeh.models import Range1d
 from bokeh.palettes import Category20
-from bokeh.plotting import ColumnDataSource
+# from bokeh.plotting import ColumnDataSource
 from bokeh.plotting import figure
 from bokeh.transform import cumsum
 from host.models import Filter
@@ -51,6 +52,101 @@ from bokeh.io import curdoc
 from host.log import get_logger
 logger = get_logger(__name__)
 
+########################################## MY ADDED CUSTOMJS ##########################################
+EDITABLE_APERTURES_HANDLE_JS = """
+const ellipses = ellipse_source.data;
+const handles = handle_source.data;
+const state = callback_state.data;
+
+// Updating handle_source ourselves causes its change callback to run again.
+// This guard prevents recursive callback execution.
+if (state.updating[0]) {
+    return;
+}
+
+state.updating[0] = true;
+
+try {
+    // Each ellipse n owns exactly two handles, laid out at fixed
+    // positions 2n (major) and 2n+1 (minor) in the shared handle source.
+    for (let n = 0; n < ellipses.x.length; n++) {
+        const majorIdx = 2 * n;
+        const minorIdx = 2 * n + 1;
+
+        const cx = ellipses.x[n];
+        const cy = ellipses.y[n];
+
+        const majorDx = handles.x[majorIdx] - cx;
+        const majorDy = handles.y[majorIdx] - cy;
+
+        // Prevent a zero-sized major axis.
+        const semiMajor = Math.max(
+            minimum_radius,
+            Math.hypot(majorDx, majorDy),
+        );
+
+        // Bokeh ellipse angles are measured in radians.
+        const theta = Math.atan2(majorDy, majorDx);
+
+        const minorUnitX = -Math.sin(theta);
+        const minorUnitY = Math.cos(theta);
+
+        const minorDx = handles.x[minorIdx] - cx;
+        const minorDy = handles.y[minorIdx] - cy;
+
+        // Project the dragged minor handle onto the true minor axis so it
+        // can't drift away from a perpendicular position.
+        const projectedMinorRadius = Math.abs(
+            minorDx * minorUnitX +
+            minorDy * minorUnitY
+        );
+
+        // Keep the aperture mathematically consistent: semi-major >= semi-minor.
+        const semiMinor = Math.min(
+            semiMajor,
+            Math.max(minimum_radius, projectedMinorRadius),
+        );
+
+        ellipses.width[n] = 2.0 * semiMajor;
+        ellipses.height[n] = 2.0 * semiMinor;
+        ellipses.angle[n] = theta;
+
+        // Snap both controls back onto their exact axes.
+        handles.x[majorIdx] = cx + semiMajor * Math.cos(theta);
+        handles.y[majorIdx] = cy + semiMajor * Math.sin(theta);
+
+        handles.x[minorIdx] = cx + semiMinor * minorUnitX;
+        handles.y[minorIdx] = cy + semiMinor * minorUnitY;
+
+        // Publish the latest unsaved geometry for this ellipse to the
+        // surrounding page. Fired for every ellipse on every callback run;
+        // the page-level listener just overwrites its cache entry, so this
+        // is cheap and avoids tracking which specific point moved.
+        window.dispatchEvent(
+            new CustomEvent("blast:aperture-change", {
+                detail: {
+                    apertureId: aperture_ids[n],
+                    apertureType: aperture_types[n],
+                    x: cx,
+                    y: cy,
+                    semiMajor: semiMajor,
+                    semiMinor: semiMinor,
+                    thetaRadians: theta,
+                },
+            })
+        );
+    }
+
+    ellipse_source.change.emit();
+    handle_source.change.emit();
+} finally {
+    state.updating[0] = false;
+    callback_state.change.emit();
+}
+"""
+
+
+########################################## ORIGINAL CODE ###############################################################
 
 def scale_image(image_data):
     transform = AsinhStretch() + PercentileInterval(99.5)
@@ -110,7 +206,154 @@ def plot_aperture(figure, aperture, wcs, plotting_kwargs=None):
     figure.ellipse(**plot_dict)
     return figure
 
+def plot_editable_apertures(figure, apertures, wcs, minimum_radius=1.0):
+    """
+    Draw one or more editable apertures sharing a single PointDrawTool.
 
+    `apertures` is a list of dicts, each with:
+        - aperture_id
+        - aperture_type ("local" or "global")
+        - sky_aperture
+        - line_color
+        - legend_label
+    """
+    ellipse_x, ellipse_y = [], []
+    ellipse_w, ellipse_h, ellipse_angle = [], [], []
+    ellipse_line_color, ellipse_legend = [], []
+
+    handle_x, handle_y, handle_color, handle_axis = [], [], [], []
+    aperture_ids, aperture_types = [], []
+
+    for ap in apertures:
+        pixel_aperture = ap["sky_aperture"].to_pixel(wcs)
+        position = np.asarray(pixel_aperture.positions, dtype=float)
+
+        center_x = float(position[0])
+        center_y = float(position[1])
+        semi_major = float(pixel_aperture.a)
+        semi_minor = float(pixel_aperture.b)
+        theta = float(pixel_aperture.theta.value)
+
+        if semi_major <= 0:
+            raise ValueError("The aperture semi-major radius must be positive.")
+        if semi_minor <= 0:
+            raise ValueError("The aperture semi-minor radius must be positive.")
+
+        # Preserve the mathematical meaning of major and minor axes.
+        if semi_minor > semi_major:
+            semi_major, semi_minor = semi_minor, semi_major
+            theta += math.pi / 2.0
+
+        ellipse_x.append(center_x)
+        ellipse_y.append(center_y)
+        ellipse_w.append(2.0 * semi_major)
+        ellipse_h.append(2.0 * semi_minor)
+        ellipse_angle.append(theta)
+        ellipse_line_color.append(ap["line_color"])
+        ellipse_legend.append(ap["legend_label"])
+
+        major_handle_x = center_x + semi_major * math.cos(theta)
+        major_handle_y = center_y + semi_major * math.sin(theta)
+        minor_handle_x = center_x - semi_minor * math.sin(theta)
+        minor_handle_y = center_y + semi_minor * math.cos(theta)
+
+        # Handles inherit the color of their own aperture so it's visually
+        # obvious which pair of handles controls which ellipse.
+        handle_x += [major_handle_x, minor_handle_x]
+        handle_y += [major_handle_y, minor_handle_y]
+        handle_color += [ap["line_color"], ap["line_color"]]
+        handle_axis += ["major", "minor"]
+
+        aperture_ids.append(ap["aperture_id"])
+        aperture_types.append(ap["aperture_type"])
+
+    ellipse_source = ColumnDataSource(
+        data={
+            "x": ellipse_x,
+            "y": ellipse_y,
+            "width": ellipse_w,
+            "height": ellipse_h,
+            "angle": ellipse_angle,
+            "line_color": ellipse_line_color,
+            "legend_label": ellipse_legend,
+        }
+    )
+
+    handle_source = ColumnDataSource(
+        data={
+            "x": handle_x,
+            "y": handle_y,
+            "line_color": handle_color,
+            "axis": handle_axis,
+        }
+    )
+
+    # Used only to prevent an infinite callback loop when the JavaScript
+    # callback snaps the handles back onto their exact axes.
+    callback_state = ColumnDataSource(data={"updating": [False]})
+
+    ellipse_renderer = figure.ellipse(
+        x="x",
+        y="y",
+        width="width",
+        height="height",
+        angle="angle",
+        source=ellipse_source,
+        fill_color="#cab2d6",
+        fill_alpha=0.1,
+        line_width=4,
+        line_color="line_color",
+        legend_field="legend_label",
+    )
+
+    handle_renderer = figure.scatter(
+        x="x",
+        y="y",
+        source=handle_source,
+        marker="circle",
+        size=14,
+        fill_color="white",
+        fill_alpha=1.0,
+        line_color="line_color",
+        line_width=3,
+        selection_fill_color="white",
+        selection_line_color="line_color",
+        nonselection_fill_color="white",
+        nonselection_fill_alpha=1.0,
+        nonselection_line_color="line_color",
+        nonselection_line_alpha=1.0,
+    )
+
+    # A single shared tool drives every editable aperture on this figure.
+    handle_tool = PointDrawTool(renderers=[handle_renderer], add=False)
+    figure.add_tools(handle_tool)
+
+    handle_callback = CustomJS(
+        args={
+            "ellipse_source": ellipse_source,
+            "handle_source": handle_source,
+            "callback_state": callback_state,
+            "aperture_ids": aperture_ids,
+            "aperture_types": aperture_types,
+            "minimum_radius": float(minimum_radius),
+        },
+        code=EDITABLE_APERTURES_HANDLE_JS,
+    )
+
+    # PointDrawTool modifies handle_source continuously while the pointer
+    # moves, so this callback runs repeatedly throughout each drag.
+    handle_source.js_on_change("data", handle_callback)
+
+    return {
+        "ellipse_source": ellipse_source,
+        "handle_source": handle_source,
+        "ellipse_renderer": ellipse_renderer,
+        "handle_renderer": handle_renderer,
+        "handle_tool": handle_tool,
+    }
+
+
+########################################## ORIGINAL CODE ###############################################################
 def plot_image_grid(image_dict, apertures=None):
     figures = []
     for survey, image in image_dict.items():
@@ -136,7 +379,7 @@ def plot_image_grid(image_dict, apertures=None):
     return {"bokeh_cutout_script": script, "bokeh_cutout_div": div}
 
 
-def plot_cutout_image(cutout=None, transient=None, global_aperture=None, local_aperture=None):
+def plot_cutout_image(cutout=None, transient=None, global_aperture=None, local_aperture=None, editable=False):
     def generate_plot(fig, image_data):
         hide_loading_indicator = CustomJS(args=dict(), code="""
             document.getElementById('loading-indicator').style.display = "none";
@@ -160,6 +403,54 @@ def plot_cutout_image(cutout=None, transient=None, global_aperture=None, local_a
         fig.ygrid.visible = False
         image_data = np.zeros((500, 500))
         return generate_plot(fig, image_data)
+    
+    def add_apertures(fig, global_aperture, local_aperture, wcs, editable):
+        specs = []
+        if global_aperture.exists():
+            specs.append({
+                "record": global_aperture[0],
+                "aperture_type": "global",
+                "line_color": "green",
+                "legend_label": "Global Aperture",
+            })
+        if local_aperture.exists():
+            specs.append({
+                "record": local_aperture[0],
+                "aperture_type": "local",
+                "line_color": "blue",
+                "legend_label": "Local Aperture",
+            })
+
+        if not specs:
+            return
+
+        if editable:
+            plot_editable_apertures(
+                fig,
+                [
+                    {
+                        "aperture_id": s["record"].id,
+                        "aperture_type": s["aperture_type"],
+                        "sky_aperture": s["record"].sky_aperture,
+                        "line_color": s["line_color"],
+                        "legend_label": s["legend_label"],
+                    }
+                    for s in specs
+                ],
+                wcs,
+            )
+        else:
+            for s in specs:
+                plot_aperture(
+                    fig,
+                    s["record"].sky_aperture,
+                    wcs,
+                    plotting_kwargs={
+                        "fill_alpha": 0.1,
+                        "line_color": s["line_color"],
+                        "legend_label": s["legend_label"],
+                    },
+                )
 
     # If there is no cutout data, generate an empty plot
     if cutout is None:
@@ -224,30 +515,6 @@ def plot_cutout_image(cutout=None, transient=None, global_aperture=None, local_a
             wcs,
             plotting_kwargs=host_kwargs,
             plotting_func=fig.scatter,
-        )
-
-    if global_aperture.exists():
-        plot_aperture(
-            fig,
-            global_aperture[0].sky_aperture,
-            wcs,
-            plotting_kwargs={
-                "fill_alpha": 0.1,
-                "line_color": "green",
-                "legend_label": f"Global Aperture ({title})",
-            },
-        )
-
-    if local_aperture.exists():
-        plot_aperture(
-            fig,
-            local_aperture[0].sky_aperture,
-            wcs,
-            plotting_kwargs={
-                "fill_alpha": 0.1,
-                "line_color": "blue",
-                "legend_label": "Local Aperture",
-            },
         )
     return generate_plot(fig, image_data=image_data)
 

--- a/app/host/plotting_utils.py
+++ b/app/host/plotting_utils.py
@@ -516,6 +516,14 @@ def plot_cutout_image(cutout=None, transient=None, global_aperture=None, local_a
             plotting_kwargs=host_kwargs,
             plotting_func=fig.scatter,
         )
+        
+    add_apertures(
+        fig,
+        global_aperture,
+        local_aperture,
+        wcs,
+        editable=editable,
+    )
     return generate_plot(fig, image_data=image_data)
 
 

--- a/app/host/templates/host/cutout_card.html
+++ b/app/host/templates/host/cutout_card.html
@@ -28,12 +28,65 @@
         <div class="input-group-append">
             <button class="btn btn-primary" type="button"
                 onclick="cutoutImgClick('{{ transient.name }}', document.getElementById('id_filters').value)">Get Cutout</button>
+            <button class="btn btn-outline-secondary" type="button" id="edit-aperture-btn"
+                onclick="toggleApertureEdit('{{ transient.name }}')">Enable Aperture Editing</button>
+            <button class="btn btn-success" type="button" id="save-aperture-btn"
+                onclick="saveApertureChanges('{{ transient.name }}')" disabled>Save Aperture Changes</button>
         </div>
     </div>
 </form>
 <script>
+    // tracks whether aperture-editing mode is currently on, so the toggle button knows what to switch to and re-request on the next click
     document.getElementById('loading-indicator').style.display = "none";
-    function cutoutImgClick(transient, filter) {
+    var apertureEditable = false;
+    
+    // caches unsaved edits fired by EDITABLE_APERTURE_HANDLE_JS, keyed by apertureId+apertureType
+    var pendingApertureChanges = {};
+
+    window.addEventListener('blast:aperture-change', function (evt) {
+        var d = evt.detail;
+        pendingApertureChanges[d.apertureId + ':' + d.apertureType] = d;
+
+        var saveBtn = document.getElementById('save-aperture-btn');
+        if (saveBtn) {
+            saveBtn.disabled = Object.keys(pendingApertureChanges).length === 0;
+        }
+    });
+
+    function toggleApertureEdit(transient) {
+        apertureEditable = !apertureEditable;
+        var btn = document.getElementById('edit-aperture-btn');
+        btn.textContent = apertureEditable ? "Disable Aperture Editing" : "Enable Aperture Editing";
+        btn.classList.toggle('btn-outline-secondary', !apertureEditable);
+        btn.classList.toggle('btn-secondary', apertureEditable);
+        var filter = document.getElementById('id_filters').value;
+        cutoutImgClick(transient, filter, apertureEditable);
+    }
+
+    function saveApertureChanges(transient) {
+        var changes = Object.values(pendingApertureChanges);
+        if (!changes.length) return;
+        $.ajax({
+            url: "{% url 'save_aperture_changes' %}",
+            type: "POST",
+            headers: { "X-CSRFToken": "{{ csrf_token }}" },
+            contentType: "application/json",
+            data: JSON.stringify({ transient_name: transient, apertures: changes }),
+            success: function (resp) {
+                pendingApertureChanges = {};
+                var saveBtn = document.getElementById('save-aperture-btn');
+                if (saveBtn) {
+                    saveBtn.disabled = true;
+                }
+            },
+            error: function (xhr) {
+                console.error("Failed to save aperture changes:", xhr.responseText);
+            },
+        });
+    }
+
+    document.getElementById('loading-indicator').style.display = "none";
+    function cutoutImgClick(transient, filter, editable) {
         document.getElementById('loading-indicator').style.display = "block";
         $("#cutout-loader-mask").show();
         $.ajax({
@@ -41,7 +94,8 @@
             type: "GET",
             data: {
                 transient_name: transient,
-                filter: filter
+                filter: filter,
+                editable: editable
             },
             success: function (resp) {
                 document.getElementById("cutout-img-bokeh").innerHTML = resp.bokeh_cutout_div;

--- a/app/host/urls.py
+++ b/app/host/urls.py
@@ -62,6 +62,7 @@ urlpatterns = [
     path(f"""{base_path}privacy""", views.privacy_policy, name='privacy'),
     path(f"""{base_path}healthz""", views.healthz, name='healthz'),
     path(f"""{base_path}cutout_fits_plot""", views.cutout_fits_plot, name='cutout_fits_plot'),
+    path(f"""{base_path}save_aperture_changes""", views.save_aperture_changes, name='save_aperture_changes'),
     path(f"""{base_path}fetch_sed_plot""", views.fetch_sed_plot, name='fetch_sed_plot'),
 ]
 

--- a/app/host/views.py
+++ b/app/host/views.py
@@ -809,6 +809,8 @@ def cutout_fits_plot(request):
     if request.method == 'GET':
         transient_name = request.GET.get('transient_name')
         filter = request.GET.get('filter')
+        editable = request.GET.get("editable", "false").lower() == "true"
+
 
         # Acquire the transient object or return 404 not found
         try:
@@ -828,5 +830,37 @@ def cutout_fits_plot(request):
             transient=transient,
             global_aperture=global_aperture.prefetch_related(),
             local_aperture=local_aperture.prefetch_related(),
+            editable=editable
         )
         return JsonResponse(bokeh_context)
+
+@login_required
+def save_aperture_changes(request):
+    if request.method != "POST":
+        return JsonResponse(
+            {"success": False, "message": "Only POST requests are allowed."},
+            status=405,
+        )
+
+    try:
+        payload = json.loads(request.body)
+    except (json.JSONDecodeError, TypeError):
+        return JsonResponse(
+            {"success": False, "message": "Invalid JSON payload."},
+            status=400,
+        )
+
+    transient_name = payload.get("transient_name")
+    apertures = payload.get("apertures", [])
+
+    if not transient_name:
+        return JsonResponse(
+            {"success": False, "message": "Missing transient_name."},
+            status=400,
+        )
+
+    return JsonResponse({
+        "success": True,
+        "transient_name": transient_name,
+        "apertures": apertures,
+    })


### PR DESCRIPTION
Implements #364 

Implemented:
- aperture rotation and scaling along major and minor axes
- switching between editing and static aperture view mode
- added save button, currently not functional

Ideas for extra features + next steps:
- have the save button re-trigger transient processing workflow
- determine how to display previous version of transients, display full "version history" of edits
- while user is in edit mode, have a fainter version of ellipse before the edits so the user can compare their changes before saving 
- after hitting edit mode, user still needs to hit additional pointdrawtool button on sidebar of bokeh plot, consider using one or the other
- implement translating the ellipse across the plot, keep separate from moving the plot